### PR TITLE
fix: 画像サイズ不一致の警告と half バリデーション追加

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,15 +58,15 @@ func handleProcess(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Half-open eye is optional.
+	// Half-open eye is optional; validate only when the field is present.
 	var half image.Image
-	if hf, _, hErr := r.FormFile("half"); hErr == nil {
-		defer hf.Close()
-		if data, rErr := io.ReadAll(hf); rErr == nil {
-			if img, _, dErr := image.Decode(bytes.NewReader(data)); dErr == nil {
-				half = img
-			}
+	if len(r.MultipartForm.File["half"]) > 0 {
+		img, err := readFormImage(r, "half")
+		if err != nil {
+			http.Error(w, "伏せ目の読み込みに失敗しました: "+err.Error(), http.StatusBadRequest)
+			return
 		}
+		half = img
 	}
 
 	preset := blink.GetPreset(r.FormValue("preset"))

--- a/static/index.html
+++ b/static/index.html
@@ -263,6 +263,19 @@
       color: #ba68c8;
     }
 
+    /* ── Dimension warning ── */
+    .dim-warn {
+      display: none;
+      margin-top: 10px;
+      padding: 8px 12px;
+      background: #fff8e1;
+      color: #e65100;
+      border-radius: 8px;
+      font-size: 0.76rem;
+      line-height: 1.45;
+    }
+    .dim-warn.show { display: block; }
+
     /* ── Mobile ── */
     @media (max-width: 420px) {
       header h1  { font-size: 1.7rem; }
@@ -327,6 +340,7 @@
       </div>
 
     </div>
+    <div class="dim-warn" id="dim-warn"></div>
   </div>
 
   <!-- Controls -->
@@ -379,6 +393,29 @@
 
 <script>
   const files = { normal: null, closed: null, half: null };
+  const dims  = {}; // { key: { w, h } } — populated on thumb load
+
+  // ── Dimension consistency check ──
+  function checkDimensions() {
+    const active = Object.keys(files).filter(k => files[k] && dims[k]);
+    if (active.length < 2) { hideDimWarn(); return; }
+    const ref = dims[active[0]];
+    const mismatch = active.some(k => dims[k].w !== ref.w || dims[k].h !== ref.h);
+    if (mismatch) {
+      const detail = active.map(k => `${k}: ${dims[k].w}×${dims[k].h}`).join('、');
+      showDimWarn(`画像サイズが揃っていません（${detail}）。自動で中央揃えされますが、コマ間でずれが生じる場合があります。`);
+    } else {
+      hideDimWarn();
+    }
+  }
+  function showDimWarn(msg) {
+    const el = document.getElementById('dim-warn');
+    el.textContent = '⚠ ' + msg;
+    el.classList.add('show');
+  }
+  function hideDimWarn() {
+    document.getElementById('dim-warn').classList.remove('show');
+  }
 
   const presetHints = {
     normal:  '自然な人間らしい瞬き（3〜5秒間隔）',
@@ -425,7 +462,12 @@
     // Revoke previous object URL to avoid memory leak.
     if (files[key]) URL.revokeObjectURL(document.getElementById('thumb-' + key).src);
     files[key] = file;
-    document.getElementById('thumb-' + key).src = URL.createObjectURL(file);
+    const thumb = document.getElementById('thumb-' + key);
+    thumb.onload = () => {
+      dims[key] = { w: thumb.naturalWidth, h: thumb.naturalHeight };
+      checkDimensions();
+    };
+    thumb.src = URL.createObjectURL(file);
     document.getElementById('zone-' + key).classList.add('filled');
     hideStatus();
   }
@@ -435,8 +477,10 @@
     e.preventDefault();
     if (files[key]) URL.revokeObjectURL(document.getElementById('thumb-' + key).src);
     files[key] = null;
+    delete dims[key];
     document.getElementById('thumb-' + key).src = '';
     document.getElementById('zone-' + key).classList.remove('filled');
+    checkDimensions();
     // Reset file input so the same file can be re-selected.
     const zone = document.getElementById('zone-' + key);
     const input = zone.querySelector('input[type=file]');


### PR DESCRIPTION
## 変更内容

### `static/index.html` — アップロード時のサイズ不一致警告

画像をアップロードするたびに `naturalWidth/Height` を読み取り、2枚以上揃った時点でサイズを比較。不一致があればアップロードカード下部に警告を表示する。

```
⚠ 画像サイズが揃っていません（normal: 500×800、closed: 480×790）。
  自動で中央揃えされますが、コマ間でずれが生じる場合があります。
```

- クリア時は `dims` エントリを削除して再チェック
- 警告は非ブロッキング（出力は続行可能）

### `main.go` — half 画像の寸法バリデーション

`half` フィールドを直接デコードしていた箇所を `readFormImage` 経由に変更し、`maxImageDim`（4096px）チェックが適用されるようにした。フィールドの有無は `r.MultipartForm.File` で判定する。

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKuvrLTNAMUTCuGHpmfBgj)_