### PR TITLE
fix: APNGの色化け・GIFの彩度低下を修正、黄色テーマ・ファイル名改善

### DIFF
--- a/encoder/apng.go
+++ b/encoder/apng.go
@@ -93,7 +93,7 @@ func EncodeAPNG(w io.Writer, frames []blink.Frame) error {
 		binary.BigEndian.PutUint16(fctl[20:22], uint16(f.Delay))
 		binary.BigEndian.PutUint16(fctl[22:24], 100)
 		fctl[24] = 0 // dispose_op: APNG_DISPOSE_OP_NONE
-		fctl[25] = 0 // blend_op:   APNG_BLEND_OP_SOURCE
+		fctl[25] = 1 // blend_op:   APNG_BLEND_OP_OVER
 
 		if err := writeChunk(w, "fcTL", fctl); err != nil {
 			return err

--- a/encoder/gif.go
+++ b/encoder/gif.go
@@ -3,10 +3,10 @@ package encoder
 import (
 	"image"
 	"image/color"
-	"image/color/palette"
 	"image/draw"
 	"image/gif"
 	"io"
+	"sort"
 
 	"blinky/blink"
 )
@@ -21,19 +21,8 @@ func EncodeGIF(w io.Writer, frames []blink.Frame) error {
 		return nil
 	}
 
-	// 256-entry palette: transparent at index 0, Plan9 colours after.
-	pal := make(color.Palette, 1, 256)
-	pal[0] = color.RGBA{0, 0, 0, 0} // transparent sentinel
-	for i, c := range palette.Plan9 {
-		if i >= 255 {
-			break
-		}
-		pal = append(pal, c)
-	}
-
+	pal := buildPalette(frames)
 	anim := &gif.GIF{LoopCount: 0}
-
-	// opaqueBlack is used as the composite background.
 	opaqueBlack := &image.Uniform{C: color.NRGBA{0, 0, 0, 255}}
 
 	for _, f := range frames {
@@ -66,4 +55,46 @@ func EncodeGIF(w io.Writer, frames []blink.Frame) error {
 	}
 
 	return gif.EncodeAll(w, anim)
+}
+
+// buildPalette samples all opaque pixels from every frame and returns a
+// 255-colour palette sorted by frequency (plus index 0 for transparency).
+// For illustration-style images this preserves the exact colours of the
+// artwork far better than a generic palette such as Plan9.
+func buildPalette(frames []blink.Frame) color.Palette {
+	counts := make(map[[3]byte]int)
+	for _, f := range frames {
+		b := f.Image.Bounds()
+		for y := b.Min.Y; y < b.Max.Y; y++ {
+			for x := b.Min.X; x < b.Max.X; x++ {
+				r, g, bl, a := f.Image.At(x, y).RGBA()
+				if a < 0x8000 {
+					continue
+				}
+				counts[[3]byte{byte(r >> 8), byte(g >> 8), byte(bl >> 8)}]++
+			}
+		}
+	}
+
+	type entry struct {
+		rgb [3]byte
+		n   int
+	}
+	entries := make([]entry, 0, len(counts))
+	for k, n := range counts {
+		entries = append(entries, entry{k, n})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].n > entries[j].n })
+
+	pal := make(color.Palette, 1, 256)
+	pal[0] = color.RGBA{0, 0, 0, 0} // transparent sentinel
+	limit := 255
+	if len(entries) < limit {
+		limit = len(entries)
+	}
+	for i := 0; i < limit; i++ {
+		e := entries[i]
+		pal = append(pal, color.RGBA{e.rgb[0], e.rgb[1], e.rgb[2], 255})
+	}
+	return pal
 }

--- a/main.go
+++ b/main.go
@@ -10,7 +10,9 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 
 	"blinky/blink"
 	"blinky/encoder"
@@ -69,6 +71,15 @@ func handleProcess(w http.ResponseWriter, r *http.Request) {
 		half = img
 	}
 
+	// Derive output base name from the uploaded normal image filename.
+	outBase := "blinky"
+	if fhs := r.MultipartForm.File["normal"]; len(fhs) > 0 {
+		stem := strings.TrimSuffix(filepath.Base(fhs[0].Filename), filepath.Ext(fhs[0].Filename))
+		if stem != "" {
+			outBase = stem + "_blinky"
+		}
+	}
+
 	preset := blink.GetPreset(r.FormValue("preset"))
 	frames := blink.GenerateFrames(normal, closed, half, preset)
 
@@ -83,14 +94,14 @@ func handleProcess(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set("Content-Type", "image/gif")
-		w.Header().Set("Content-Disposition", `attachment; filename="blink.gif"`)
+		w.Header().Set("Content-Disposition", `attachment; filename="`+outBase+`.gif"`)
 	default: // apng
 		if err := encoder.EncodeAPNG(&buf, frames); err != nil {
 			http.Error(w, "APNG生成に失敗しました: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
 		w.Header().Set("Content-Type", "image/png")
-		w.Header().Set("Content-Disposition", `attachment; filename="blink.png"`)
+		w.Header().Set("Content-Disposition", `attachment; filename="`+outBase+`.png"`)
 	}
 
 	w.Header().Set("Content-Length", strconv.Itoa(buf.Len()))

--- a/static/index.html
+++ b/static/index.html
@@ -9,10 +9,10 @@
 
     body {
       font-family: 'Segoe UI', 'Hiragino Sans', 'Meiryo', sans-serif;
-      background: linear-gradient(145deg, #fce4ec 0%, #f3e5f5 55%, #ede7f6 100%);
+      background: linear-gradient(145deg, #fffde7 0%, #fff9c4 55%, #fef9c3 100%);
       min-height: 100vh;
       padding: 16px;
-      color: #3e2060;
+      color: #78350f;
     }
 
     .wrap {
@@ -28,12 +28,12 @@
     header h1 {
       font-size: 2.2rem;
       letter-spacing: 0.06em;
-      color: #6a1b9a;
+      color: #b45309;
     }
     header p {
       margin-top: 6px;
       font-size: 0.88rem;
-      color: #9c27b0;
+      color: #d97706;
     }
 
     /* ── Card ── */
@@ -42,12 +42,12 @@
       border-radius: 18px;
       padding: 22px 20px;
       margin-bottom: 14px;
-      box-shadow: 0 2px 14px rgba(106, 27, 154, 0.08);
+      box-shadow: 0 2px 14px rgba(180, 83, 9, 0.08);
     }
     .card-title {
       font-size: 0.82rem;
       font-weight: 700;
-      color: #7b1fa2;
+      color: #92400e;
       letter-spacing: 0.05em;
       text-transform: uppercase;
       margin-bottom: 14px;
@@ -62,23 +62,23 @@
 
     .drop-zone {
       position: relative;
-      border: 2px dashed #ce93d8;
+      border: 2px dashed #fcd34d;
       border-radius: 14px;
       padding: 10px 6px 12px;
       text-align: center;
       cursor: pointer;
       transition: border-color 0.18s, background 0.18s;
-      background: #fdf6ff;
+      background: #fffbeb;
       user-select: none;
     }
     .drop-zone:hover,
     .drop-zone.drag-over {
-      border-color: #9c27b0;
-      background: #f3e5f5;
+      border-color: #f59e0b;
+      background: #fef3c7;
     }
     .drop-zone.filled {
       border-style: solid;
-      border-color: #ab47bc;
+      border-color: #f59e0b;
     }
 
     /* hidden file input overlaid on the zone */
@@ -114,11 +114,11 @@
     .drop-zone .lbl {
       font-size: 0.75rem;
       font-weight: 700;
-      color: #7b1fa2;
+      color: #92400e;
     }
     .drop-zone .sub {
       font-size: 0.65rem;
-      color: #ba68c8;
+      color: #d97706;
       margin-top: 2px;
     }
 
@@ -129,7 +129,7 @@
       right: 6px;
       width: 20px;
       height: 20px;
-      background: rgba(156, 39, 176, 0.7);
+      background: rgba(217, 119, 6, 0.7);
       border: none;
       border-radius: 50%;
       color: #fff;
@@ -154,27 +154,27 @@
       display: block;
       font-size: 0.78rem;
       font-weight: 700;
-      color: #7b1fa2;
+      color: #92400e;
       margin-bottom: 6px;
     }
     .ctrl select {
       width: 100%;
       padding: 10px 32px 10px 12px;
-      border: 2px solid #e1bee7;
+      border: 2px solid #fde68a;
       border-radius: 10px;
       font-size: 0.88rem;
-      color: #4a148c;
-      background: #fff url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%237b1fa2' d='M6 8 0 0h12z'/%3E%3C/svg%3E") no-repeat right 12px center;
+      color: #78350f;
+      background: #fff url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%23d97706' d='M6 8 0 0h12z'/%3E%3C/svg%3E") no-repeat right 12px center;
       appearance: none;
       cursor: pointer;
     }
     .ctrl select:focus {
       outline: none;
-      border-color: #9c27b0;
+      border-color: #f59e0b;
     }
     .ctrl .hint {
       font-size: 0.68rem;
-      color: #ab47bc;
+      color: #d97706;
       margin-top: 5px;
       min-height: 1em;
     }
@@ -183,7 +183,7 @@
     .gen-btn {
       width: 100%;
       padding: 14px;
-      background: linear-gradient(135deg, #d48de8 0%, #9c27b0 100%);
+      background: linear-gradient(135deg, #fcd34d 0%, #d97706 100%);
       color: #fff;
       font-size: 1rem;
       font-weight: 700;
@@ -195,7 +195,7 @@
     }
     .gen-btn:hover:not(:disabled) {
       transform: translateY(-2px);
-      box-shadow: 0 6px 20px rgba(156, 39, 176, 0.35);
+      box-shadow: 0 6px 20px rgba(217, 119, 6, 0.35);
     }
     .gen-btn:disabled {
       opacity: 0.55;
@@ -260,7 +260,7 @@
       text-align: center;
       padding: 18px 0 10px;
       font-size: 0.72rem;
-      color: #ba68c8;
+      color: #d97706;
     }
 
     /* ── Dimension warning ── */


### PR DESCRIPTION
## 修正内容

### fix(apng): 瞬きの瞬間に色がおかしくなる問題

**原因**: `fcTL` の `blend_op` に `APNG_BLEND_OP_SOURCE`（0）を使用していた。  
SOURCE は各フレームでキャンバスを完全置換するため、閉じ目・伏せ目フレームの透明ピクセルがそのままページの白背景を透過してしまい、通常顔（黒背景など）との切り替えで色が飛んで見えた。

**修正**: `blend_op` を `APNG_BLEND_OP_OVER`（1）に変更。  
OVER は透明ピクセルを前フレームの内容に合成するため、瞬きフレームの透明部分には直前の通常顔の背景色が維持される。ループ時も通常顔（不透明）が OVER で完全上書きされるため整合性が保たれる。

### fix(gif): 彩度が落ちる問題

**原因**: Go の汎用256色パレット（Plan9）を使用していたため、イラストの具体的な色（茶色の髪、肌色など）に近い色が少なく彩度が下がった。

**修正**: 全フレームのピクセルをサンプリングし、出現頻度順に並べた255色の専用パレットを生成するように変更。イラスト系画像では実際の色をそのまま保持できるため、Plan9 との比較で彩度が大幅に改善する。

### feat(main): 出力ファイル名を通常顔の画像名ベースに

`blink.png` / `blink.gif` の固定名から `{通常顔ファイル名}_blinky.png` / `.gif` に変更。

### feat(ui): テーマカラーを紫 → 黄（アンバー）に変更

背景・テキスト・ボタン・ボーダー等の紫系カラーをアンバー系（`#f59e0b` / `#d97706` / `#92400e` など）に統一。

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKuvrLTNAMUTCuGHpmfBgj)_